### PR TITLE
Fix: Use virtualenv in Dockerfile to address PEP 668

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM n8nio/n8n:latest
 
 USER root
 
+RUN python3 -m venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
 # Install additional dependencies if needed
 RUN apk add --no-cache \
     python3 \
     py3-pip \
-    && pip3 install --no-cache-dir requests
+    && /opt/venv/bin/pip install --no-cache-dir requests
 
 USER node
 


### PR DESCRIPTION
Modifies the Dockerfile to create and use a Python virtual environment for installing the 'requests' package.

This resolves the 'externally-managed-environment' error (PEP 668) by ensuring that pip packages are installed into an isolated environment, preventing conflicts with system-managed Python packages.

Changes include:
- Adding a RUN instruction to create a virtual environment using 'python3 -m venv /opt/venv'.
- Setting the PATH environment variable to include '/opt/venv/bin'.
- Updating the 'pip install' command to use the pip executable from the virtual environment.