### PR TITLE
Fix: Correct Dockerfile order for Python and venv setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,13 @@ FROM n8nio/n8n:latest
 
 USER root
 
-RUN python3 -m venv /opt/venv
+# Install Python, create venv, and install requests
+RUN apk add --no-cache python3 py3-pip && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir requests
 
+# Add venv to PATH for subsequent commands
 ENV PATH="/opt/venv/bin:$PATH"
-
-# Install additional dependencies if needed
-RUN apk add --no-cache \
-    python3 \
-    py3-pip \
-    && /opt/venv/bin/pip install --no-cache-dir requests
 
 USER node
 


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect command order in the Dockerfile. Previously, `python3 -m venv` was called before `python3` was installed via `apk`.

The corrected Dockerfile now ensures:
1. `python3` and `py3-pip` are installed using `apk`.
2. A virtual environment is created using `python3 -m venv`.
3. The `requests` package is installed into this virtual environment. These steps are combined into a single RUN instruction.
4. The `PATH` environment variable is updated to include the virtual environment's bin directory after these operations.

This resolves the `python3: not found` error and correctly implements the use of a virtual environment to address PEP 668.