### PR TITLE
Fix: Correct startCommand in railway.toml for n8n service

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "dockerfile"
 dockerfilePath = "Dockerfile"
 
 [deploy]
-startCommand = "docker-compose up -d"
+startCommand = "n8n start"
 healthcheckPath = "/"
 healthcheckTimeout = 100
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Changes the `deploy.startCommand` in `railway.toml` from `"docker-compose up -d"` to `"n8n start"`.

This aligns the Railway deployment configuration with the Dockerfile's intended `CMD` ("n8n start") and resolves the error where Railway was attempting to use `docker-compose` for a service meant to be run directly from its Docker image.