### PR TITLE
Fix: Update healthcheckPath to /healthz in railway.toml

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,7 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 startCommand = "n8n start"
-healthcheckPath = "/"
+healthcheckPath = "/healthz"
 healthcheckTimeout = 100
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
Changes the `deploy.healthcheckPath` in `railway.toml` from `"/"` to `"/healthz"`.

This aligns the Railway health check configuration with the standard n8n health endpoint, which should resolve previous deployment failures related to health checks.